### PR TITLE
Set priors for S_PARAM

### DIFF
--- a/R/hpl_glmm_mix_model.R
+++ b/R/hpl_glmm_mix_model.R
@@ -51,6 +51,7 @@ run_hpl_glmm_mix_model <- function(method = c("sample", "vb", "pathfinder"),
                                    a_sig2_offset = NULL, b_sig2_offset = NULL,
                                    a_sig2_u = NULL, b_sig2_u = NULL,
                                    normfactors_known = FALSE,
+                                   A_S = NULL, B_S = NULL,
                                    S_DATA = NULL, ...) {
   method <- match.arg(method)
   N_g <- nrow(X_g)
@@ -74,8 +75,12 @@ run_hpl_glmm_mix_model <- function(method = c("sample", "vb", "pathfinder"),
   if (normfactors_known) {
     # TODO: use calc_norm_factors() instead
     S_DATA <- S_DATA %||% rep(0, N_g) # nolint
+    A_S <- A_S %||% 0 # nolint
+    B_S <- B_S %||% 0.1 # nolint
   } else {
     S_DATA <- numeric(0)
+    A_S <- numeric(0)
+    B_S <- numeric(0)
   }
 
   standata <- list(
@@ -97,7 +102,9 @@ run_hpl_glmm_mix_model <- function(method = c("sample", "vb", "pathfinder"),
     a_sig2_u = a_sig2_u %||% rep(10, U), # nolint
     b_sig2_u = b_sig2_u %||% rep(1, U), # nolint
     normfactors_known = normfactors_known,
-    S_DATA = S_DATA
+    S_DATA = S_DATA,
+    A_S = A_S,
+    B_S = B_S
   )
 
   model <- instantiate::stan_package_model(

--- a/R/hpl_glmm_mix_model.R
+++ b/R/hpl_glmm_mix_model.R
@@ -13,6 +13,8 @@
 #' for each sample; optional, if `NULL` and `normfactors_known == TRUE`,
 #' normalization factors will be estimated by the `TMM` method as
 #' described in the `{edgeR}` package
+#' @param A_S location parameter for `S_PARAM` if `!normfactors_known`
+#' @param B_S scale parameter for `S_PARAM` if `!normfactors_known`
 #' @param comps Matrix encoding bernoulli mixture priors
 #' @param prob Vector giving the prior probability of each combination of
 #' bernoulli components, i.e. of each row in `comps`
@@ -75,12 +77,12 @@ run_hpl_glmm_mix_model <- function(method = c("sample", "vb", "pathfinder"),
   if (normfactors_known) {
     # TODO: use calc_norm_factors() instead
     S_DATA <- S_DATA %||% rep(0, N_g) # nolint
-    A_S <- A_S %||% 0 # nolint
-    B_S <- B_S %||% 0.1 # nolint
-  } else {
-    S_DATA <- numeric(0)
     A_S <- numeric(0)
     B_S <- numeric(0)
+  } else {
+    S_DATA <- numeric(0)
+    A_S <- A_S %||% 0 # nolint
+    B_S <- B_S %||% 0.1 # nolint
   }
 
   standata <- list(

--- a/man/run_hpl_glmm_mix_model.Rd
+++ b/man/run_hpl_glmm_mix_model.Rd
@@ -24,6 +24,8 @@ run_hpl_glmm_mix_model(
   a_sig2_u = NULL,
   b_sig2_u = NULL,
   normfactors_known = FALSE,
+  A_S = NULL,
+  B_S = NULL,
   S_DATA = NULL,
   ...
 )

--- a/man/run_hpl_glmm_mix_model.Rd
+++ b/man/run_hpl_glmm_mix_model.Rd
@@ -82,6 +82,10 @@ for Inverse Gamma priors on `sig2_u`}
 \item{normfactors_known}{Use fixed normalization factors extrinsic to
 the model?}
 
+\item{A_S}{location parameter for `S_PARAM` if `!normfactors_known`}
+
+\item{B_S}{scale parameter for `S_PARAM` if `!normfactors_known`}
+
 \item{S_DATA}{Numeric vector of normalization factors
 for each sample; optional, if `NULL` and `normfactors_known == TRUE`,
 normalization factors will be estimated by the `TMM` method as

--- a/man/run_hpl_glmm_mix_mt_model.Rd
+++ b/man/run_hpl_glmm_mix_mt_model.Rd
@@ -25,6 +25,8 @@ run_hpl_glmm_mix_mt_model(
   a_sig2_u = NULL,
   b_sig2_u = NULL,
   normfactors_known = FALSE,
+  A_S = NULL,
+  B_S = NULL,
   S_DATA = NULL,
   ...
 )
@@ -82,6 +84,10 @@ for Inverse Gamma priors on `sig2_u`}
 
 \item{normfactors_known}{Use fixed normalization factors extrinsic to
 the model?}
+
+\item{A_S}{location parameter for `S_PARAM` if `!normfactors_known`}
+
+\item{B_S}{scale parameter for `S_PARAM` if `!normfactors_known`}
 
 \item{S_DATA}{Numeric vector of normalization factors
 for each sample; optional, if `NULL` and `normfactors_known == TRUE`,

--- a/src/stan/hpl_glmm_mix.stan
+++ b/src/stan/hpl_glmm_mix.stan
@@ -32,6 +32,8 @@ data {
     array[N_g * G] int<lower=0> y;
     int<lower=0, upper=1> normfactors_known; // fixed normalization factors?
     vector[normfactors_known ? N_g : 0] S_DATA;
+    array[normfactors_known ? 0 : 1] real A_S;
+    array[normfactors_known ? 0 : 1] real<lower=0> B_S;
     int<lower=0> N_mix;
     int<lower=1> N_comps;
     array[N_comps] row_vector[K] comps;
@@ -103,7 +105,7 @@ model {
     sig2_mu ~ inv_gamma(a_sig2_mu, b_sig2_mu);
     sig2_u ~ inv_gamma(a_sig2_u, b_sig2_u);
     if (!normfactors_known) {
-        S_PARAM ~ normal(0, 1);
+        S_PARAM ~ normal(A_S, B_S);
     }
     for (g in 1:G) {
         beta[g] ~ normal(mu, sig2);


### PR DESCRIPTION
Allow the user to provide location and scale for the prior distribution of `S_PARAM`, when normalization factors are not treated as fixed and estimated exogenously to the model